### PR TITLE
Fix Cloud Run deployment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+**/node_modules
+**/dist
+.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+# Build stage
+FROM node:18 AS build
+WORKDIR /app
+COPY buddy-tales_-ai-dialogue-studio/package*.json ./buddy-tales_-ai-dialogue-studio/
+RUN cd buddy-tales_-ai-dialogue-studio && npm ci
+COPY buddy-tales_-ai-dialogue-studio ./buddy-tales_-ai-dialogue-studio
+RUN cd buddy-tales_-ai-dialogue-studio && npm run build
+
+# Runtime stage
+FROM node:18-slim
+WORKDIR /app
+COPY --from=build /app/buddy-tales_-ai-dialogue-studio /app
+EXPOSE 8080
+ENV NODE_ENV=production
+CMD ["npm", "start"]

--- a/buddy-tales_-ai-dialogue-studio/README.md
+++ b/buddy-tales_-ai-dialogue-studio/README.md
@@ -1,6 +1,6 @@
 # Run and deploy your AI Studio app
 
-This contains everything you need to run your app locally.
+This contains everything you need to run your app locally or deploy it to Google Cloud Run.
 
 ## Run Locally
 
@@ -12,3 +12,22 @@ This contains everything you need to run your app locally.
 2. Set the `GEMINI_API_KEY` in [.env.local](.env.local) to your Gemini API key
 3. Run the app:
    `npm run dev`
+
+## Deploy to Cloud Run
+
+1. **Build the container**
+
+   ```bash
+   gcloud builds submit --tag gcr.io/PROJECT_ID/btvo
+   ```
+
+2. **Deploy**
+
+   ```bash
+   gcloud run deploy btvo \
+     --image gcr.io/PROJECT_ID/btvo \
+     --region REGION \
+     --set-env-vars GEMINI_API_KEY=YOUR_API_KEY
+   ```
+
+Replace `PROJECT_ID` and `REGION` with your project details. `GEMINI_API_KEY` must be provided so the app can access the Gemini API.

--- a/buddy-tales_-ai-dialogue-studio/package.json
+++ b/buddy-tales_-ai-dialogue-studio/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "start": "vite preview --host 0.0.0.0 --port $PORT"
   },
   "dependencies": {
     "react": "^19.1.0",

--- a/buddy-tales_-ai-dialogue-studio/services/geminiService.ts
+++ b/buddy-tales_-ai-dialogue-studio/services/geminiService.ts
@@ -8,10 +8,13 @@ import { pcmToWav, generateSineWave } from '../utils/audioUtils';
 // as specified in the project brief. The output is a placeholder tone, not real speech.
 // Real speech for PREVIEWS is handled separately using the browser's built-in TTS.
 
-if (!process.env.API_KEY) {
+// The Gemini API key is provided via the GEMINI_API_KEY environment variable at
+// runtime. The value is also embedded during build so the app works with `vite
+// preview`.
+if (!process.env.GEMINI_API_KEY) {
     throw new Error("Gemini API key not found in environment variables.");
 }
-const ai = new GoogleGenAI({ apiKey: process.env.API_KEY });
+const ai = new GoogleGenAI({ apiKey: process.env.GEMINI_API_KEY });
 
 const TEXT_MODEL = 'gemini-2.5-flash';
 

--- a/buddy-tales_-ai-dialogue-studio/vite.config.ts
+++ b/buddy-tales_-ai-dialogue-studio/vite.config.ts
@@ -5,7 +5,6 @@ export default defineConfig(({ mode }) => {
     const env = loadEnv(mode, '.', '');
     return {
       define: {
-        'process.env.API_KEY': JSON.stringify(env.GEMINI_API_KEY),
         'process.env.GEMINI_API_KEY': JSON.stringify(env.GEMINI_API_KEY)
       },
       resolve: {


### PR DESCRIPTION
## Summary
- add production `start` script for Cloud Run
- switch code and config to use `GEMINI_API_KEY`
- add Dockerfile and `.dockerignore`
- document Cloud Run deployment

## Testing
- `npm install`
- `npm run build`
- `docker build` *(fails: `docker: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6880c91b96b8832aa840ef755594e160